### PR TITLE
[FIX] import of useEffect and useReducer in usePalette.tsx for SSR bundling

### DIFF
--- a/src/usePalette.tsx
+++ b/src/usePalette.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useReducer } from "react";
+import React from "react";
+const { useEffect, useReducer } = React;
 import { getPalette, PaletteColors } from "./getPalette";
 
 export type PaletteState = {


### PR DESCRIPTION
Includes tiny changes to imports of React hooks in usePalette.tsx
Fix according to this [issue](https://github.com/gatsbyjs/gatsby/issues/22599)
This fixes #14 